### PR TITLE
Create .gitattributes with basic export-ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
++/man export-ignore
++/tests export-ignore
++.gitattributes export-ignore


### PR DESCRIPTION
Files and directories with the attribute export-ignore won’t be added to archive files. This will prevent composer from downloading unnecessary files (i.e: tests) when --prefer-dist is set.
